### PR TITLE
Remove un-needed clones in tracking undo stack

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1069,8 +1069,12 @@ impl Reedline {
                         .set_buffer(buffer_to_paint, UndoBehavior::HistoryNavigation);
                 } else {
                     // Hack
-                    self.editor
-                        .set_line_buffer(original, UndoBehavior::HistoryNavigation);
+                    self.editor.edit_buffer(
+                        |lb| {
+                            *lb = original;
+                        },
+                        UndoBehavior::HistoryNavigation,
+                    );
                 }
             }
             HistoryNavigationQuery::PrefixSearch(prefix) => {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -359,6 +359,7 @@ impl UndoBehavior {
         match (previous, self) {
             // Never start an undo set with cursor movement
             (_, UB::MoveCursor) => false,
+            (_, UB::UndoRedo) => false,
             (UB::HistoryNavigation, UB::HistoryNavigation) => false,
             // When inserting/deleting repeatedly, each undo set should encompass
             // inserting/deleting a complete word and the associated whitespace

--- a/src/menu/list_menu.rs
+++ b/src/menu/list_menu.rs
@@ -480,13 +480,16 @@ impl Menu for ListMenu {
             if append_whitespace {
                 value.push(' ');
             }
-            let mut line_buffer = editor.line_buffer().clone();
-            line_buffer.replace_range(start..end, &value);
+            let offset = editor.line_buffer().insertion_point()
+                + value.len().saturating_sub(end.saturating_sub(start));
 
-            let mut offset = line_buffer.insertion_point();
-            offset += value.len().saturating_sub(end.saturating_sub(start));
-            line_buffer.set_insertion_point(offset);
-            editor.set_line_buffer(line_buffer, UndoBehavior::CreateUndoPoint);
+            editor.edit_buffer(
+                |lb| {
+                    lb.replace_range(start..end, &value);
+                    lb.set_insertion_point(offset);
+                },
+                UndoBehavior::CreateUndoPoint,
+            );
         }
     }
 


### PR DESCRIPTION
With this change, we no longer need to clone the Editor's LineBuffer
on edits that don't cause a new insertion into the undo stack.

Previously, the EditStack always needed to have a copy of the current state.
With some tweaks to the API now the Editor has the sole copy of the
current state, so we don't need to make extra clones for the EditStack.